### PR TITLE
Add a check to find column names that do not follow naming convention

### DIFF
--- a/sql/btree_indexes_on_array_columns.sql
+++ b/sql/btree_indexes_on_array_columns.sql
@@ -13,8 +13,8 @@
 select
     i.indrelid::regclass::text as table_name,
     i.indexrelid::regclass::text as index_name,
-    col.attname::text as column_name,
     col.attnotnull as column_not_null,
+    quote_ident(col.attname::text) as column_name,
     pg_relation_size(i.indexrelid) as index_size
 from pg_catalog.pg_index i
     inner join pg_catalog.pg_class ic on ic.oid = i.indexrelid

--- a/sql/columns_not_following_naming_convention.sql
+++ b/sql/columns_not_following_naming_convention.sql
@@ -5,10 +5,12 @@
  * Licensed under the Apache License 2.0
  */
 
--- Finds columns of type 'json'. Use 'jsonb' instead.
+-- Finds columns whose names do not follow naming convention (that have to be enclosed in double-quotes).
+-- You should avoid using quoted column names.
 --
--- See also https://www.postgresql.org/docs/current/datatype-json.html
--- and https://medium.com/geekculture/postgres-jsonb-usage-and-performance-analysis-cdbd1242a018
+-- See https://www.postgresql.org/docs/17/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+-- See also https://lerner.co.il/2013/11/30/quoting-postgresql/
+-- See also https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names
 select
     t.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
@@ -22,6 +24,6 @@ where
     not t.relispartition and
     col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
     not col.attisdropped and
-    col.atttypid = 'json'::regtype and
+    (col.attname ~ '[A-Z]' or col.attname ~ '[^a-z0-9_]') and /* column name has characters that require quoting */
     nsp.nspname = :schema_name_param::text
 order by table_name, column_name;

--- a/sql/columns_with_serial_types.sql
+++ b/sql/columns_with_serial_types.sql
@@ -13,9 +13,9 @@ with
     t as (
         select
             col.attrelid::regclass::text as table_name,
-            col.attname::text as column_name,
             col.attnotnull as column_not_null,
             nsp.nspname as schema_name,
+            quote_ident(col.attname::text) as column_name,
             case col.atttypid
                 when 'int'::regtype then 'serial'
                 when 'int8'::regtype then 'bigserial'

--- a/sql/columns_without_description.sql
+++ b/sql/columns_without_description.sql
@@ -9,8 +9,8 @@
 -- See also https://www.postgresql.org/docs/current/sql-comment.html
 select
     pc.oid::regclass::text as table_name,
-    col.attname::text as column_name,
-    col.attnotnull as column_not_null
+    col.attnotnull as column_not_null,
+    quote_ident(col.attname::text) as column_name
 from
     pg_catalog.pg_class pc
     inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace

--- a/sql/indexes_with_boolean.sql
+++ b/sql/indexes_with_boolean.sql
@@ -9,8 +9,8 @@
 select
     pi.indrelid::regclass::text as table_name,
     pi.indexrelid::regclass::text as index_name,
-    col.attname::text as column_name,
     col.attnotnull as column_not_null,
+    quote_ident(col.attname::text) as column_name,
     pg_relation_size(pi.indexrelid) as index_size
 from
     pg_catalog.pg_index pi

--- a/sql/primary_keys_with_serial_types.sql
+++ b/sql/primary_keys_with_serial_types.sql
@@ -22,9 +22,9 @@ with
     t as (
         select
             col.attrelid::regclass::text as table_name,
-            col.attname::text as column_name,
             col.attnotnull as column_not_null,
             s.seqrelid::regclass::text as sequence_name,
+            quote_ident(col.attname::text) as column_name,
             case col.atttypid
                 when 'int'::regtype then 'serial'
                 when 'int8'::regtype then 'bigserial'


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/606