### PR TITLE
Add check for indexes "timestamp in the middle"

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 31. Indexes with unnecessary where-clause on not null column ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_unnecessary_where_clause.sql)).
 32. Primary keys that are most likely natural keys ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/primary_keys_that_most_likely_natural_keys.sql)).
 33. Columns with [money](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_money) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_money_type.sql)).
+34. Indexes with a [timestamp in the middle](https://habr.com/ru/companies/tensor/articles/488104/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_timestamp_in_the_middle.sql)).
 
 ## Local development
 

--- a/sql/btree_indexes_on_array_columns.sql
+++ b/sql/btree_indexes_on_array_columns.sql
@@ -16,7 +16,8 @@ select
     col.attnotnull as column_not_null,
     quote_ident(col.attname) as column_name,
     pg_relation_size(pi.indexrelid) as index_size
-from pg_catalog.pg_index pi
+from
+    pg_catalog.pg_index pi
     inner join pg_catalog.pg_class ic on ic.oid = pi.indexrelid
     inner join pg_catalog.pg_namespace nsp on nsp.oid = ic.relnamespace
     inner join pg_catalog.pg_am am on am.oid = ic.relam and am.amname = 'btree'

--- a/sql/btree_indexes_on_array_columns.sql
+++ b/sql/btree_indexes_on_array_columns.sql
@@ -8,7 +8,7 @@
 -- Finds B-tree indexes on array columns
 --
 -- GIN-index should be used instead for such columns
--- Based on query from https://habr.com/ru/articles/800121/
+-- Based on a query from https://habr.com/ru/articles/800121/
 -- See also https://www.postgresql.org/docs/current/catalog-pg-type.html#CATALOG-TYPCATEGORY-TABLE
 select
     pi.indrelid::regclass::text as table_name,

--- a/sql/duplicated_foreign_keys.sql
+++ b/sql/duplicated_foreign_keys.sql
@@ -7,7 +7,7 @@
 
 -- Finds completely identical foreign keys
 --
--- Based on query from https://habr.com/ru/articles/803841/
+-- Based on a query from https://habr.com/ru/articles/803841/
 with
     fk_with_attributes as (
         select

--- a/sql/foreign_keys_with_unmatched_column_type.sql
+++ b/sql/foreign_keys_with_unmatched_column_type.sql
@@ -13,7 +13,7 @@
 -- and reduces the number of errors that may appear due to type inconsistencies in the future.
 --
 -- See https://www.postgresql.org/docs/current/catalog-pg-constraint.html
--- Based on query from https://habr.com/ru/articles/803841/
+-- Based on a query from https://habr.com/ru/articles/803841/
 with
     fk_with_attributes as (
         select

--- a/sql/indexes_with_timestamp_in_the_middle.sql
+++ b/sql/indexes_with_timestamp_in_the_middle.sql
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds indexes in which columns with the timestamp[tz] type are not the last.
+--
+-- It always looks suspicious if in your index a field with obviously greater variation of the timestamp[tz] type is not the last.
+-- You would better to use ESR rule: Equality → Sort → Range
+-- When creating a composite B-tree index:
+--     E — Equality: first, the columns for which the query uses =
+--     S — Sort: then the ones that are sorted (ORDER BY)
+--     R — Range: and only at the end are columns with ranges (>, <, BETWEEN)
+-- See https://habr.com/ru/articles/911688/
+-- See also https://www.postgresql.org/docs/current/indexes-multicolumn.html
+--
+-- Based on a query from https://habr.com/ru/companies/tensor/articles/488104/
+with
+    columns_with_opclass as (
+        select
+            pi.indrelid as table_oid,
+            pi.indexrelid as index_oid,
+            array_agg(
+                case
+                    when a.attnum is not null then quote_ident(a.attname) || ',' || a.attnotnull::text
+                    else quote_ident(pg_get_indexdef(pi.indexrelid, u.attposition::int, true)) || ',true'
+                end
+                order by u.attposition
+            ) as columns,
+            array_agg(replace(op.opcname::text, '_ops', '') order by u.attposition) as opclasses
+        from
+            pg_catalog.pg_index pi
+            inner join pg_catalog.pg_class pc on pc.oid = pi.indexrelid
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+            left join lateral unnest(pi.indkey) with ordinality as u(attnum, attposition) on true
+            left join pg_catalog.pg_attribute a on a.attrelid = pi.indrelid and a.attnum = u.attnum
+            left join lateral unnest(pi.indclass) with ordinality as opclass(opcoid, op_attposition) on attposition = op_attposition
+            left join pg_catalog.pg_opclass op on op.oid = opclass.opcoid
+        where
+            nsp.nspname = :schema_name_param::text and
+            not pi.indisunique and
+            pi.indisready and
+            pi.indisvalid and
+            not pc.relispartition
+        group by pi.indrelid, pi.indexrelid
+    )
+
+select
+    opc.table_oid::regclass::text as table_name,
+    opc.index_oid::regclass::text as index_name,
+    opc.columns as columns,
+    pg_relation_size(opc.index_oid) as index_size
+from
+    columns_with_opclass opc
+where
+    array_length(opc.opclasses,1) > 1 and
+    (
+        'timestamp' = any(opc.opclasses[1:array_upper(opc.opclasses,1)-1]) or
+        'timestamptz' = any(opc.opclasses[1:array_upper(opc.opclasses,1)-1])
+    )
+order by table_name, index_name;

--- a/sql/indexes_with_timestamp_in_the_middle.sql
+++ b/sql/indexes_with_timestamp_in_the_middle.sql
@@ -32,11 +32,11 @@ with
             array_agg(replace(op.opcname::text, '_ops', '') order by u.attposition) as opclasses
         from
             pg_catalog.pg_index pi
-            inner join pg_catalog.pg_class pc on pc.oid = pi.indexrelid
+            inner join pg_catalog.pg_class pc on pc.oid = pi.indrelid
             inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
-            left join lateral unnest(pi.indkey) with ordinality as u(attnum, attposition) on true
+            left join lateral unnest(pi.indkey) with ordinality u(attnum, attposition) on true
             left join pg_catalog.pg_attribute a on a.attrelid = pi.indrelid and a.attnum = u.attnum
-            left join lateral unnest(pi.indclass) with ordinality as uop(opcoid, attposition) on u.attposition = uop.attposition
+            left join lateral unnest(pi.indclass) with ordinality uop(opcoid, attposition) on uop.attposition = u.attposition
             left join pg_catalog.pg_opclass op on op.oid = uop.opcoid
         where
             nsp.nspname = :schema_name_param::text and
@@ -57,7 +57,7 @@ from
 where
     array_length(opc.opclasses,1) > 1 and
     (
-        'timestamp' = any(opc.opclasses[1:array_upper(opc.opclasses,1)-1]) or
-        'timestamptz' = any(opc.opclasses[1:array_upper(opc.opclasses,1)-1])
+        'timestamp' = any(opc.opclasses[1:array_upper(opc.opclasses,1) - 1]) or
+        'timestamptz' = any(opc.opclasses[1:array_upper(opc.opclasses,1) - 1])
     )
 order by table_name, index_name;

--- a/sql/indexes_with_unnecessary_where_clause.sql
+++ b/sql/indexes_with_unnecessary_where_clause.sql
@@ -10,12 +10,12 @@ select
     pc.oid::regclass::text as table_name,
     pi.indexrelid::regclass::text as index_name,
     pg_relation_size(pi.indexrelid) as index_size,
-    array_agg(quote_ident(a.attname) || ',' || a.attnotnull::text order by u.ordinality) as columns
+    array_agg(quote_ident(a.attname) || ',' || a.attnotnull::text order by u.attposition) as columns
 from
     pg_catalog.pg_index pi
     inner join pg_catalog.pg_class pc on pc.oid = pi.indrelid
     inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
-    inner join unnest(pi.indkey) with ordinality u(attnum, ordinality) on true
+    inner join unnest(pi.indkey) with ordinality u(attnum, attposition) on true
     inner join pg_catalog.pg_attribute a on a.attrelid = pc.oid and a.attnum = u.attnum
 where
     pc.relkind in ('r', 'p') and /* regular and partitioned tables */

--- a/sql/intersected_foreign_keys.sql
+++ b/sql/intersected_foreign_keys.sql
@@ -7,7 +7,7 @@
 
 -- Finds partially identical foreign keys (with overlapping sets of columns).
 --
--- Based on query from https://habr.com/ru/articles/803841/
+-- Based on a query from https://habr.com/ru/articles/803841/
 with
     fk_with_attributes as (
         select

--- a/sql/not_valid_constraints.sql
+++ b/sql/not_valid_constraints.sql
@@ -7,7 +7,7 @@
 
 -- Finds not validated constraints
 --
--- Based on query from https://habr.com/ru/articles/800121/
+-- Based on a query from https://habr.com/ru/articles/800121/
 select
     c.conrelid::regclass::text as table_name,
     c.contype as constraint_type,

--- a/sql/primary_keys_with_varchar.sql
+++ b/sql/primary_keys_with_varchar.sql
@@ -16,12 +16,12 @@ select
     pc.oid::regclass::text as table_name,
     pi.indexrelid::regclass as index_name,
     pg_relation_size(pi.indexrelid) as index_size,
-    array_agg(quote_ident(a.attname) || ',' || a.attnotnull::text order by u.ordinality) as columns
+    array_agg(quote_ident(a.attname) || ',' || a.attnotnull::text order by u.attposition) as columns
 from
     pg_catalog.pg_class pc
     inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
     inner join pg_catalog.pg_index pi on pi.indrelid = pc.oid
-    inner join unnest(pi.indkey) with ordinality u(attnum, ordinality) on true
+    inner join unnest(pi.indkey) with ordinality u(attnum, attposition) on true
     inner join pg_catalog.pg_attribute a on a.attrelid = pc.oid and a.attnum = u.attnum
 where
     not a.attisdropped and

--- a/sql/sequence_overflow.sql
+++ b/sql/sequence_overflow.sql
@@ -7,7 +7,7 @@
 
 -- Finds sequences that may overflow in the near future
 --
--- Based on query from https://habr.com/ru/articles/800121/
+-- Based on a query from https://habr.com/ru/articles/800121/
 with
     all_sequences as (
         select

--- a/sql/tables_not_linked_to_others.sql
+++ b/sql/tables_not_linked_to_others.sql
@@ -10,7 +10,7 @@
 -- These are often service tables that are not part of the project, or
 -- tables that are no longer in use or were created by mistake, but were not deleted in a timely manner.
 --
--- Based on query from https://habr.com/ru/articles/803841/
+-- Based on a query from https://habr.com/ru/articles/803841/
 with
     nsp as (
         select


### PR DESCRIPTION
### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

Part of https://github.com/mfvanek/pg-index-health/issues/387