### PR TITLE
Add a new check "prefer timestamptz instead of timestamp"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 5. Foreign keys without associated indexes ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_without_index.sql)).
 6. Indexes with null values ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_null_values.sql)).
 7. Tables with missing indexes ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_missing_indexes.sql)).
-8. Tables without primary key ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_without_primary_key.sql)).
+8. Tables without a primary key ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_without_primary_key.sql)).
 9. Indexes [bloat](https://www.percona.com/blog/2018/08/06/basic-understanding-bloat-vacuum-postgresql-mvcc/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/bloated_indexes.sql)).
 10. Tables [bloat](https://www.percona.com/blog/2018/08/06/basic-understanding-bloat-vacuum-postgresql-mvcc/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/bloated_tables.sql)).
 11. Tables without [description](https://www.postgresql.org/docs/current/sql-comment.html) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_without_description.sql)).
@@ -51,17 +51,18 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 21. Duplicated (completely identical) foreign keys ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/duplicated_foreign_keys.sql)).
 22. Intersected (partially identical) foreign keys ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/intersected_foreign_keys.sql)).
 23. Objects with possible name overflow ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/possible_object_name_overflow.sql)).
-24. Tables not linked to other tables ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_not_linked_to_others.sql)).
+24. Tables are not linked to other tables ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_not_linked_to_others.sql)).
 25. Foreign keys [with unmatched column type](https://habr.com/ru/articles/803841/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_unmatched_column_type.sql)).
-26. Tables with zero or one column ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_zero_or_one_column.sql)).
-27. Objects whose names do not follow naming convention ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/objects_not_following_naming_convention.sql)).
-28. Columns whose names do not follow naming convention ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_not_following_naming_convention.sql)).
+26. Tables with zero or one columns ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_zero_or_one_column.sql)).
+27. Objects whose names do not follow the naming convention ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/objects_not_following_naming_convention.sql)).
+28. Columns whose names do not follow the naming convention ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_not_following_naming_convention.sql)).
 29. Primary keys with varchar columns instead of uuids ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/primary_keys_with_varchar.sql)).
 30. Columns with [varchar(n)](https://www.postgresql.org/docs/current/datatype-character.html) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_fixed_length_varchar.sql)).
 31. Indexes with unnecessary where-clause on not null column ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_unnecessary_where_clause.sql)).
 32. Primary keys that are most likely natural keys ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/primary_keys_that_most_likely_natural_keys.sql)).
 33. Columns with [money](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_money) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_money_type.sql)).
 34. Indexes with a [timestamp in the middle](https://habr.com/ru/companies/tensor/articles/488104/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_timestamp_in_the_middle.sql)).
+35. Columns with a [timestamp](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_timestamp_or_timetz_type.sql)).
 
 ## Local development
 
@@ -77,7 +78,7 @@ docker run \
   -e USE_FIND_ALGORITHM=true \
   -e VALIDATE_SQLFLUFF=true \
   -v $(pwd):/tmp/lint \
-  ghcr.io/super-linter/super-linter:slim-v7.4.0
+  ghcr.io/super-linter/super-linter:slim-v8.1.0
 ```
 
 #### Windows
@@ -90,7 +91,7 @@ docker run ^
   -e USE_FIND_ALGORITHM=true ^
   -e VALIDATE_SQLFLUFF=true ^
   -v "%cd%":/tmp/lint ^
-  ghcr.io/super-linter/super-linter:slim-v7.4.0
+  ghcr.io/super-linter/super-linter:slim-v8.1.0
 ```
 
 See https://github.com/super-linter/super-linter/blob/main/dependencies/python/sqlfluff.txt
@@ -100,5 +101,5 @@ docker run --rm ^
   -v "%cd%\.github\linters\.sqlfluff":/sql/.sqlfluff:ro ^
   -v "%cd%":/sql ^
   -e SQLFLUFF_CONFIG=/sql/.sqlfluff ^
-  sqlfluff/sqlfluff:3.4.0 lint /sql
+  sqlfluff/sqlfluff:3.4.2 lint /sql
 ```

--- a/sql/columns_with_fixed_length_varchar.sql
+++ b/sql/columns_with_fixed_length_varchar.sql
@@ -11,6 +11,7 @@
 select
     t.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
+    col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
     pg_catalog.pg_class t

--- a/sql/columns_with_money_type.sql
+++ b/sql/columns_with_money_type.sql
@@ -5,11 +5,11 @@
  * Licensed under the Apache License 2.0
  */
 
--- Finds columns of type 'money'.
--- Use `numeric` type instead (possibly with the currency being used in an adjacent column).
+-- Finds columns of the type 'money'.
+-- Use the `numeric` type instead (possibly with the currency being used in an adjacent column).
 --
--- Money type doesn't handle fractions of a cent (or equivalents in other currencies),
--- it's rounding behavior is probably not what you want.
+-- Money type doesn't handle fractions of a cent (or equivalents in other currencies).
+-- Its rounding behavior is probably not what you want.
 -- It doesn't store a currency with the value, rather assuming
 -- that all money columns contain the currency specified by the database's lc_monetary locale setting.
 -- If you change the lc_monetary setting for any reason, all money columns will contain the wrong value.
@@ -18,6 +18,7 @@
 select
     t.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
+    col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
     pg_catalog.pg_class t

--- a/sql/columns_with_timestamp_or_timetz_type.sql
+++ b/sql/columns_with_timestamp_or_timetz_type.sql
@@ -5,10 +5,12 @@
  * Licensed under the Apache License 2.0
  */
 
--- Finds columns of type 'json'. Use 'jsonb' instead.
+-- Finds columns of type 'timestamp (without time zone)' or 'timetz' in the specified schema.
+-- Don't use the timestamp type to store timestamps, use timestamptz (also known as timestamp with time zone) instead.
+-- Don't use the timetz type. You probably want timestamptz instead.
 --
--- See also https://www.postgresql.org/docs/current/datatype-json.html
--- and https://medium.com/geekculture/postgres-jsonb-usage-and-performance-analysis-cdbd1242a018
+-- See https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29
+-- See https://wiki.postgresql.org/wiki/Don't_Do_This#Don't_use_timetz
 select
     t.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
@@ -21,8 +23,8 @@ from
 where
     t.relkind in ('r', 'p') and
     not t.relispartition and
-    col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
+    col.attnum > 0 and /* to filter out system columns */
     not col.attisdropped and
-    col.atttypid = 'json'::regtype and
+    col.atttypid in ('timestamp without time zone'::regtype, 'timetz'::regtype) and
     nsp.nspname = :schema_name_param::text
 order by table_name, column_name;

--- a/sql/indexes_with_boolean.sql
+++ b/sql/indexes_with_boolean.sql
@@ -5,11 +5,12 @@
  * Licensed under the Apache License 2.0
  */
 
--- Finds indexes that contains boolean values.
+-- Finds indexes that contain boolean values.
 select
     pi.indrelid::regclass::text as table_name,
     pi.indexrelid::regclass::text as index_name,
     col.attnotnull as column_not_null,
+    col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name,
     pg_relation_size(pi.indexrelid) as index_size
 from

--- a/sql/indexes_with_null_values.sql
+++ b/sql/indexes_with_null_values.sql
@@ -21,7 +21,7 @@ where
     not a.attnotnull and
     not ic.relispartition and
     nsp.nspname = :schema_name_param::text and
-    array_position(pi.indkey, a.attnum) = 0 and /* only for first segment */
+    array_position(pi.indkey, a.attnum) = 0 and /* only for the first segment */
     (pi.indpred is null or (position(lower(a.attname) in lower(pg_get_expr(pi.indpred, pi.indrelid))) = 0))
 group by pi.indrelid, pi.indexrelid, pi.indpred
 order by table_name, index_name;


### PR DESCRIPTION
### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

Relates to https://github.com/mfvanek/pg-index-health/issues/313