### PR TITLE
Add a check for tables where the primary key columns are not first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@
 
 Each database structure check starts with an SQL query to the pg_catalog.
 
-1. [SQLFluff](https://github.com/sqlfluff/sqlfluff) is used as a linter for all sql queries
-2. All queries must be schema-aware, i.e. we filter out database objects on schema basis:
+1. [SQLFluff](https://github.com/sqlfluff/sqlfluff) is used as a linter for all SQL queries
+2. All queries must be schema-aware, i.e. we filter out database objects on a schema basis:
    ```sql
    where
        nsp.nspname = :schema_name_param::text
@@ -26,5 +26,5 @@ Each database structure check starts with an SQL query to the pg_catalog.
 6. All query results must be ordered in some way.
 7. All queries must have a brief description.
    Links to documentation or articles with detailed descriptions are welcome.
-8. Name of the sql-file with query must correspond to diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health).
-9. Do not forget to update `README.md`.
+8. The name of the sql-file with a query must correspond to diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health).
+9. Remember to update `README.md`.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 33. Columns with [money](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_money) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_money_type.sql)).
 34. Indexes with a [timestamp in the middle](https://habr.com/ru/companies/tensor/articles/488104/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_timestamp_in_the_middle.sql)).
 35. Columns with a [timestamp](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_timestamp_or_timetz_type.sql)).
+36. Tables where the primary key columns are not first ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_primary_key_columns_not_first.sql)).
 
 ## Local development
 

--- a/sql/tables_where_primary_key_columns_not_first.sql
+++ b/sql/tables_where_primary_key_columns_not_first.sql
@@ -15,8 +15,9 @@
 with
     target_tables as (
         select pc.oid
-        from pg_catalog.pg_class pc
-        inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+        from
+            pg_catalog.pg_class pc
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
         where
             nsp.nspname = :schema_name_param::text and
             pc.relkind in ('r', 'p') and
@@ -27,8 +28,9 @@ with
         select
             t.oid as table_oid,
             a.attname as first_column
-        from target_tables t
-        inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum > 0 and not a.attisdropped
+        from
+            target_tables t
+            inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum > 0 and not a.attisdropped
         where
             a.attnum = (
                 select min(att.attnum)
@@ -44,9 +46,10 @@ with
         select
             c.conrelid as table_oid,
             pg_catalog.array_agg(a.attname order by a.attnum) as pk_columns
-        from pg_catalog.pg_constraint c
-        inner join target_tables t on t.oid = c.conrelid
-        inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum = any(c.conkey)
+        from
+            pg_catalog.pg_constraint c
+            inner join target_tables t on t.oid = c.conrelid
+            inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum = any(c.conkey)
         where
             c.contype = 'p'
         group by c.conrelid
@@ -55,8 +58,9 @@ with
 select
     f.table_oid::regclass::text as table_name,
     pg_table_size(f.table_oid) as table_size
-from first_columns f
-inner join pk_columns p on p.table_oid = f.table_oid
+from
+    first_columns f
+    inner join pk_columns p on p.table_oid = f.table_oid
 where
     f.first_column <> p.pk_columns[1]
 order by table_name;

--- a/sql/tables_where_primary_key_columns_not_first.sql
+++ b/sql/tables_where_primary_key_columns_not_first.sql
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds tables where the primary key columns are not first.
+--
+-- Putting the primary key as the first column is mostly a style and convention thing rather than a technical requirement.
+-- It improves readability, consistency, and expectations, especially in teams or large schemas.
+-- It helps with tooling, introspection, and makes schema definitions easier to understand at a glance.
+--
+-- Similar to schemacrawler.tools.linter.LinterTableWithPrimaryKeyNotFirst https://www.schemacrawler.com/lint.html
+with
+    target_tables as (
+        select pc.oid
+        from pg_catalog.pg_class pc
+        inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+        where
+            nsp.nspname = :schema_name_param::text and
+            pc.relkind in ('r', 'p') and
+            not pc.relispartition
+    ),
+
+    first_columns as (
+        select
+            t.oid as table_oid,
+            a.attname as first_column
+        from target_tables t
+        inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum > 0 and not a.attisdropped
+        where
+            a.attnum = (
+                select min(att.attnum)
+                from pg_catalog.pg_attribute att
+                where
+                    att.attrelid = t.oid and
+                    att.attnum > 0 and
+                    not att.attisdropped
+            )
+    ),
+
+    pk_columns as (
+        select
+            c.conrelid as table_oid,
+            pg_catalog.array_agg(a.attname order by a.attnum) as pk_columns
+        from pg_catalog.pg_constraint c
+        inner join target_tables t on t.oid = c.conrelid
+        inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum = any(c.conkey)
+        where
+            c.contype = 'p'
+        group by c.conrelid
+    )
+
+select
+    f.table_oid::regclass::text as table_name,
+    pg_table_size(f.table_oid) as table_size
+from first_columns f
+inner join pk_columns p on p.table_oid = f.table_oid
+where
+    f.first_column <> p.pk_columns[1]
+order by table_name;


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/634

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [X] Linked to an issue
- [X] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
