### PR TITLE
Tables that have all columns besides the primary key that are nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 34. Indexes with a [timestamp in the middle](https://habr.com/ru/companies/tensor/articles/488104/) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/indexes_with_timestamp_in_the_middle.sql)).
 35. Columns with a [timestamp](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_timestamp_or_timetz_type.sql)).
 36. Tables where the primary key columns are not first ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_primary_key_columns_not_first.sql)).
+37. Tables that have all columns besides the primary key that are nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_all_columns_nullable_except_pk.sql)).
 
 ## Local development
 

--- a/sql/tables_where_all_columns_nullable_except_pk.sql
+++ b/sql/tables_where_all_columns_nullable_except_pk.sql
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds tables that have all columns besides the primary key that are nullable.
+-- Such tables may contain no useful data and could indicate a schema design smell.
+--
+-- Similar to schemacrawler.tools.linter.LinterTableAllNullableColumns https://www.schemacrawler.com/lint.html
+with
+    target_tables as (
+        select pc.oid
+        from
+            pg_catalog.pg_class pc
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+        where
+            nsp.nspname = :schema_name_param::text and
+            pc.relkind in ('r', 'p') and
+            not pc.relispartition
+    ),
+
+    pk_columns as (
+        select
+            c.conrelid as table_oid,
+            array_agg(a.attnum) as pk_attnums
+        from
+            pg_catalog.pg_constraint c
+            inner join target_tables t on t.oid = c.conrelid
+            inner join pg_catalog.pg_attribute a on a.attrelid = t.oid and a.attnum = any(c.conkey)
+        where
+            c.contype = 'p'
+        group by c.conrelid
+     ),
+
+    all_nullable as (
+        select
+            t.oid as table_oid,
+            bool_and(
+                a.attnotnull = false or
+                a.attnum = any (coalesce(pk.pk_attnums, '{}'))
+            ) as all_nonpk_nullable
+        from
+            target_tables t
+            inner join pg_catalog.pg_attribute a on a.attrelid = t.oid
+            left join pk_columns pk on pk.table_oid = t.oid
+        where
+            a.attnum > 0 and
+            not a.attisdropped
+        group by t.oid
+    )
+
+select
+    a.table_oid::regclass::text as table_name,
+    pg_table_size(a.table_oid) as table_size
+from
+    all_nullable a
+where
+    a.all_nonpk_nullable = true
+order by table_name;

--- a/sql/tables_where_all_columns_nullable_except_pk.sql
+++ b/sql/tables_where_all_columns_nullable_except_pk.sql
@@ -32,7 +32,7 @@ with
         where
             c.contype = 'p'
         group by c.conrelid
-     ),
+    ),
 
     all_nullable as (
         select

--- a/sql/tables_where_all_columns_nullable_except_pk.sql
+++ b/sql/tables_where_all_columns_nullable_except_pk.sql
@@ -39,7 +39,7 @@ with
             t.oid as table_oid,
             bool_and(
                 a.attnotnull = false or
-                a.attnum = any (coalesce(pk.pk_attnums, '{}'))
+                a.attnum = any(coalesce(pk.pk_attnums, '{}'))
             ) as all_nonpk_nullable
         from
             target_tables t

--- a/sql/tables_where_all_columns_nullable_except_pk.sql
+++ b/sql/tables_where_all_columns_nullable_except_pk.sql
@@ -37,6 +37,7 @@ with
     all_nullable as (
         select
             t.oid as table_oid,
+            count(*) filter (where pk.pk_attnums is null or a.attnum <> all(pk.pk_attnums)) as nonpk_count,
             bool_and(
                 a.attnotnull = false or
                 a.attnum = any(coalesce(pk.pk_attnums, '{}'))
@@ -57,5 +58,6 @@ select
 from
     all_nullable a
 where
-    a.all_nonpk_nullable = true
+    a.all_nonpk_nullable = true and
+    a.nonpk_count > 0 /* ensure there is at least one non-pk column */
 order by table_name;

--- a/sql/tables_where_primary_key_columns_not_first.sql
+++ b/sql/tables_where_primary_key_columns_not_first.sql
@@ -45,7 +45,7 @@ with
     pk_columns as (
         select
             c.conrelid as table_oid,
-            pg_catalog.array_agg(a.attname order by a.attnum) as pk_columns
+            array_agg(a.attname order by a.attnum) as pk_columns
         from
             pg_catalog.pg_constraint c
             inner join target_tables t on t.oid = c.conrelid


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/630

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
