### PR TITLE
Add new check "Don't use char(n)" [pgwiki] [squawk]

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 35. Columns with a [timestamp](https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29) type ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_timestamp_or_timetz_type.sql)).
 36. Tables where the primary key columns are not first ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_primary_key_columns_not_first.sql)).
 37. Tables that have all columns besides the primary key that are nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_all_columns_nullable_except_pk.sql)).
+38. Columns with [char(n) type](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n)) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_char_type.sql)).
 
 ## Local development
 

--- a/sql/columns_with_char_type.sql
+++ b/sql/columns_with_char_type.sql
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds columns of type char, char(n), character(n) or bpchar(n).
+--
+-- Do not use the type 'char(n)'. You should use the type 'text' instead.
+-- Any string you insert into a char(n) field will be padded with spaces to the declared width.
+-- The space-padding does waste space but does not make operations on it any faster.
+--
+-- See https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n)
+-- See https://www.postgresql.org/docs/current/datatype-character.html
+-- See also https://squawkhq.com/docs/ban-char-field
+select
+    t.oid::regclass::text as table_name,
+    col.attnotnull as column_not_null,
+    col.atttypid::regtype::text as column_type,
+    quote_ident(col.attname) as column_name
+from
+    pg_catalog.pg_class t
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+where
+    t.relkind in ('r', 'p') and
+    not t.relispartition and
+    col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
+    not col.attisdropped and
+    col.atttypid in ('character'::regtype, 'char'::regtype, 'bpchar'::regtype) and
+    col.atttypmod > 0 and /* only for fixed length varchar (not varchar without n) */
+    nsp.nspname = :schema_name_param::text
+order by table_name, column_name;

--- a/sql/primary_keys_with_varchar.sql
+++ b/sql/primary_keys_with_varchar.sql
@@ -6,7 +6,7 @@
  */
 
 -- Finds primary keys with columns of varchar(32/36/38) type.
--- Usually these columns should use built-in uuid type.
+-- Usually these columns should use a built-in uuid type.
 --
 -- See https://www.postgresql.org/docs/17/datatype-uuid.html
 -- b9b1f6f5-7f90-4b68-a389-f0ad8bb5784b - with dashes - 36 characters


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/705

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
