### PR TITLE
Add a check "Don't use table inheritance" [pgwiki]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 36. Tables where the primary key columns are not first ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_primary_key_columns_not_first.sql)).
 37. Tables that have all columns besides the primary key that are nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_all_columns_nullable_except_pk.sql)).
 38. Columns with [char(n) type](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n)) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_char_type.sql)).
+39. Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)).
 
 ## Local development
 

--- a/sql/tables_with_inheritance.sql
+++ b/sql/tables_with_inheritance.sql
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019-2025. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds tables that use table inheritance.
+-- Never use table inheritance. This is a completely bad idea.
+--
+-- See https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance
+-- Not applicable to partitioned tables
+select
+    pc.oid::regclass::text as table_name,
+    pg_table_size(pc.oid) as table_size
+from
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_inherits i on i.inhrelid = pc.oid /* child table oid */
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+where
+    pc.relkind = 'r' and
+    nsp.nspname = :schema_name_param::text
+order by table_name;


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/669

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
