### PR TITLE
TABLES_WITH_INHERITANCE should ignore partitioned tables

### DIFF
--- a/sql/tables_with_inheritance.sql
+++ b/sql/tables_with_inheritance.sql
@@ -19,5 +19,6 @@ from
     inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
 where
     pc.relkind = 'r' and
+    not pc.relispartition and /* skip partitioned tables */
     nsp.nspname = :schema_name_param::text
 order by table_name;


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/767

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [ ] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [ ] Sql query has a brief description
- [ ] Sql query contains filtering by schema name
- [ ] All tables, indexes and sequences names in the query results are schema-qualified
- [ ] All names have been enclosed in double quotes (if necessary)
- [ ] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [ ] All query results have been ordered
- [ ] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
