### PR TITLE
Add a new check "Multicolumn foreign keys where at least one of the referencing columns is nullable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 37. Tables that have all columns besides the primary key that are nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_where_all_columns_nullable_except_pk.sql)).
 38. Columns with [char(n) type](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n)) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_char_type.sql)).
 39. Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)).
+40. Multicolumn foreign keys where at least one of the referencing columns is nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)).
 
 ## Local development
 

--- a/sql/foreign_keys_with_null_values.sql
+++ b/sql/foreign_keys_with_null_values.sql
@@ -25,9 +25,9 @@ with
             quote_ident(c.conname) as constraint_name
         from
             pg_catalog.pg_constraint c
-                inner join pg_catalog.pg_namespace nsp on nsp.oid = c.connamespace
-                inner join lateral unnest(c.conkey) with ordinality u(attnum, attposition) on true
-                inner join pg_catalog.pg_attribute col on col.attrelid = c.conrelid and col.attnum = u.attnum
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = c.connamespace
+            inner join lateral unnest(c.conkey) with ordinality u(attnum, attposition) on true
+            inner join pg_catalog.pg_attribute col on col.attrelid = c.conrelid and col.attnum = u.attnum
         where
             c.contype = 'f' and
             array_length(c.conkey, 1) > 1 and

--- a/sql/foreign_keys_with_null_values.sql
+++ b/sql/foreign_keys_with_null_values.sql
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds multicolumn foreign keys where at least one of the referencing columns is nullable
+-- and a match type on constraint is not MATCH FULL.
+--
+-- MATCH FULL will not allow one column of a multicolumn foreign key to be null unless all foreign key columns are null;
+-- if they are all null, the row is not required to have a match in the referenced table.
+-- MATCH SIMPLE (which is the default) allows any of the foreign key columns to be null;
+-- if any of them are null, the row is not required to have a match in the referenced table.
+--
+-- See https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK
+-- Based on a query from https://habr.com/ru/articles/803841/
+with
+    fk_with_attributes as (
+        select
+            c.conrelid as table_oid,
+            u.attposition,
+            col.attnotnull,
+            quote_ident(col.attname) as column_name,
+            quote_ident(c.conname) as constraint_name
+        from
+            pg_catalog.pg_constraint c
+                inner join pg_catalog.pg_namespace nsp on nsp.oid = c.connamespace
+                inner join lateral unnest(c.conkey) with ordinality u(attnum, attposition) on true
+                inner join pg_catalog.pg_attribute col on col.attrelid = c.conrelid and col.attnum = u.attnum
+        where
+            c.contype = 'f' and
+            array_length(c.conkey, 1) > 1 and
+            c.confmatchtype <> 'f' and  /* not match full */
+            c.conparentid = 0 and c.coninhcount = 0 and /* not a constraint in a partition */
+            nsp.nspname = :schema_name_param::text
+    ),
+
+    fk_with_attributes_grouped as (
+        select
+            constraint_name,
+            table_oid,
+            array_agg(column_name || ',' || attnotnull::text order by attposition) as columns
+        from fk_with_attributes
+        group by constraint_name, table_oid
+        having bool_or(attnotnull = false) /* at least one referencing column is nullable */
+    )
+
+select
+    table_oid::regclass::text as table_name,
+    constraint_name,
+    columns
+from
+    fk_with_attributes_grouped
+order by table_name, constraint_name;


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/389

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
