### PR TITLE
Add a new check "Objects with upper case names" (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,14 @@ sql/ext/          # Extension-dependent queries (requires pg_stat_statements)
 3. Update `README.md` to add the check to the table.
 4. Open a PR linked to an existing issue; complete every item in the PR checklist.
 
+### Object-level vs column-level checks
+When a check applies to both database objects (tables, indexes, sequences, views, functions, constraints) and columns, split it into two separate files:
+- `objects_*.sql` — covers object-level names only; returns `object_name` and `object_type`.
+- `columns_*.sql` — covers column-level names only; returns `table_name`, `column_not_null`, and `column_name`.
+
+See `objects_with_upper_case_names.sql` / `columns_with_upper_case_names.sql` and
+`objects_not_following_naming_convention.sql` / `columns_not_following_naming_convention.sql` as examples.
+
 ## Supported PostgreSQL Versions
 
 PostgreSQL 14, 15, 16, 17, and 18. PostgreSQL 13 and earlier are not supported.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,4 +47,10 @@ Each database structure check starts with an SQL query against `pg_catalog`.
 13. All queries must have a brief description.
     Links to documentation or articles with detailed descriptions are welcome.
 14. The SQL file name must match the corresponding diagnostic name in the [Java project](https://github.com/mfvanek/pg-index-health).
-15. Remember to update `README.md`.
+15. When a check applies to both database objects (tables, indexes, sequences, views, functions, constraints) and columns, split it into two separate files:
+    - `objects_*.sql` — covers object-level names only; returns `object_name` and `object_type`.
+    - `columns_*.sql` — covers column-level names only; returns `table_name`, `column_not_null`, and `column_name`.
+
+    See `objects_with_upper_case_names.sql` / `columns_with_upper_case_names.sql` and
+    `objects_not_following_naming_convention.sql` / `columns_not_following_naming_convention.sql` as examples.
+16. Remember to update `README.md`.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 38. Columns with [char(n) type](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don't_use_char(n)) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_char_type.sql)).
 39. Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)).
 40. Multicolumn foreign keys where at least one of the referencing columns is nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)).
+41. Objects whose names contain [uppercase letters](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/objects_with_upper_case_names.sql)).
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 39. Tables with [inheritance](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_table_inheritance) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_inheritance.sql)).
 40. Multicolumn foreign keys where at least one of the referencing columns is nullable ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/foreign_keys_with_null_values.sql)).
 41. Objects whose names contain [uppercase letters](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/objects_with_upper_case_names.sql)).
+42. Columns whose names contain [uppercase letters](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_upper_case_names.sql)).
 
 ## Local development
 

--- a/sql/btree_indexes_on_array_columns.sql
+++ b/sql/btree_indexes_on_array_columns.sql
@@ -18,13 +18,13 @@ select
     pg_relation_size(pi.indexrelid) as index_size
 from
     pg_catalog.pg_index pi
-    inner join pg_catalog.pg_class ic on ic.oid = pi.indexrelid
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = ic.relnamespace
-    inner join pg_catalog.pg_am am on am.oid = ic.relam and am.amname = 'btree'
+    inner join pg_catalog.pg_class pc on pc.oid = pi.indexrelid
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_am am on am.oid = pc.relam and am.amname = 'btree'
     inner join pg_catalog.pg_attribute col on col.attrelid = pi.indrelid and col.attnum = any((string_to_array(pi.indkey::text, ' ')::int2[])[:pi.indnkeyatts])
     inner join pg_catalog.pg_type typ on typ.oid = col.atttypid
 where
     nsp.nspname = :schema_name_param::text and
-    not ic.relispartition and
+    not pc.relispartition and
     typ.typcategory = 'A' /* A stands for Array type */
 order by table_name, index_name;

--- a/sql/columns_not_following_naming_convention.sql
+++ b/sql/columns_not_following_naming_convention.sql
@@ -12,16 +12,16 @@
 -- See also https://lerner.co.il/2013/11/30/quoting-postgresql/
 -- See also https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
     not col.attisdropped and
     (col.attname ~ '[A-Z]' or col.attname ~ '[^a-z0-9_]') and /* column name has characters that require quoting */

--- a/sql/columns_with_char_type.sql
+++ b/sql/columns_with_char_type.sql
@@ -15,17 +15,17 @@
 -- See https://www.postgresql.org/docs/current/datatype-character.html
 -- See also https://squawkhq.com/docs/ban-char-field
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
     not col.attisdropped and
     col.atttypid in ('character'::regtype, 'char'::regtype, 'bpchar'::regtype) and

--- a/sql/columns_with_fixed_length_varchar.sql
+++ b/sql/columns_with_fixed_length_varchar.sql
@@ -9,17 +9,17 @@
 --
 -- See also https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_varchar.28n.29_by_default
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
     not col.attisdropped and
     col.atttypid = 'varchar'::regtype and

--- a/sql/columns_with_json_type.sql
+++ b/sql/columns_with_json_type.sql
@@ -10,17 +10,17 @@
 -- See also https://www.postgresql.org/docs/current/datatype-json.html
 -- and https://medium.com/geekculture/postgres-jsonb-usage-and-performance-analysis-cdbd1242a018
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
     not col.attisdropped and
     col.atttypid = 'json'::regtype and

--- a/sql/columns_with_money_type.sql
+++ b/sql/columns_with_money_type.sql
@@ -16,17 +16,17 @@
 --
 -- See https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_money
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns */
     not col.attisdropped and
     col.atttypid = 'money'::regtype and

--- a/sql/columns_with_serial_types.sql
+++ b/sql/columns_with_serial_types.sql
@@ -27,9 +27,9 @@ with
                 else null::text
             end as sequence_name
         from
-            pg_catalog.pg_class t
-            inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-            inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+            pg_catalog.pg_class pc
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+            inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
             inner join pg_catalog.pg_attrdef ad on ad.adrelid = col.attrelid and ad.adnum = col.attnum
             left join lateral (
                 select sum(case when c.contype = 'p' then +1 else -1 end) as res
@@ -42,8 +42,8 @@ with
                 group by c.conrelid, c.conkey[1]
             ) c on true
         where
-            t.relkind in ('r', 'p') and
-            not t.relispartition and
+            pc.relkind in ('r', 'p') and
+            not pc.relispartition and
             col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
             not col.attisdropped and
             col.atttypid = any('{int,int8,int2}'::regtype[]) and

--- a/sql/columns_with_timestamp_or_timetz_type.sql
+++ b/sql/columns_with_timestamp_or_timetz_type.sql
@@ -12,17 +12,17 @@
 -- See https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timestamp_.28without_time_zone.29
 -- See https://wiki.postgresql.org/wiki/Don't_Do_This#Don't_use_timetz
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     col.atttypid::regtype::text as column_type,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns */
     not col.attisdropped and
     col.atttypid in ('timestamp without time zone'::regtype, 'timetz'::regtype) and

--- a/sql/columns_with_upper_case_names.sql
+++ b/sql/columns_with_upper_case_names.sql
@@ -11,16 +11,16 @@
 --
 -- See also https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     col.attnotnull as column_not_null,
     quote_ident(col.attname) as column_name
 from
-    pg_catalog.pg_class t
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+    pg_catalog.pg_class pc
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
 where
-    t.relkind in ('r', 'p') and
-    not t.relispartition and
+    pc.relkind in ('r', 'p') and
+    not pc.relispartition and
     col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
     not col.attisdropped and
     col.attname ~ '[A-Z]' and

--- a/sql/columns_with_upper_case_names.sql
+++ b/sql/columns_with_upper_case_names.sql
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds columns whose names contain uppercase letters.
+-- Prefer names_like_this over NamesLikeThis.
+-- PostgreSQL folds unquoted identifiers to lowercase, so using uppercase forces you to always quote the identifier.
+--
+-- See also https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names
+select
+    t.oid::regclass::text as table_name,
+    col.attnotnull as column_not_null,
+    quote_ident(col.attname) as column_name
+from
+    pg_catalog.pg_class t
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = t.relnamespace
+    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+where
+    t.relkind in ('r', 'p') and
+    not t.relispartition and
+    col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
+    not col.attisdropped and
+    col.attname ~ '[A-Z]' and
+    nsp.nspname = :schema_name_param::text
+order by table_name, column_name;

--- a/sql/indexes_with_null_values.sql
+++ b/sql/indexes_with_null_values.sql
@@ -13,13 +13,13 @@ select
     pg_relation_size(pi.indexrelid) as index_size
 from
     pg_catalog.pg_index pi
-    inner join pg_catalog.pg_class ic on ic.oid = pi.indexrelid
-    inner join pg_catalog.pg_namespace nsp on nsp.oid = ic.relnamespace
+    inner join pg_catalog.pg_class pc on pc.oid = pi.indexrelid
+    inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
     inner join pg_catalog.pg_attribute a on a.attrelid = pi.indrelid and a.attnum = any(pi.indkey)
 where
     not pi.indisunique and
     not a.attnotnull and
-    not ic.relispartition and
+    not pc.relispartition and
     nsp.nspname = :schema_name_param::text and
     array_position(pi.indkey, a.attnum) = 0 and /* only for the first segment */
     (pi.indpred is null or (position(lower(a.attname) in lower(pg_get_expr(pi.indpred, pi.indrelid))) = 0))

--- a/sql/objects_with_upper_case_names.sql
+++ b/sql/objects_with_upper_case_names.sql
@@ -62,7 +62,6 @@ with
         where
             c.conname ~ '[A-Z]' and
             c.conparentid = 0 and c.coninhcount = 0 /* not a constraint in a partition */
-
     )
 
 select *

--- a/sql/objects_with_upper_case_names.sql
+++ b/sql/objects_with_upper_case_names.sql
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds database objects whose names contain uppercase letters.
+-- Prefer names_like_this over NamesLikeThis.
+-- PostgreSQL folds unquoted identifiers to lowercase, so using uppercase forces you to always quote the identifier.
+--
+-- See also https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names
+with
+    nsp as (
+        select
+            nsp.oid,
+            nsp.nspname
+        from pg_catalog.pg_namespace nsp
+        where
+            nsp.nspname = :schema_name_param::text
+    ),
+
+    upper_case_names as (
+        select
+            pc.oid::regclass::text as object_name,
+            case pc.relkind
+                when 'r' then 'table'
+                when 'i' then 'index'
+                when 'S' then 'sequence'
+                when 'v' then 'view'
+                when 'm' then 'materialized view'
+                when 'p' then 'partitioned table'
+                when 'I' then 'partitioned index'
+            end as object_type
+        from
+            pg_catalog.pg_class pc
+            inner join nsp on nsp.oid = pc.relnamespace
+        where
+            pc.relkind in ('r', 'i', 'S', 'v', 'm', 'p', 'I') and
+            /* decided not to filter by the pc.relispartition field here */
+            pc.relname ~ '[A-Z]'
+
+        union all
+
+        select
+            case when nsp.nspname = 'public' then quote_ident(p.proname) else quote_ident(nsp.nspname) || '.' || quote_ident(p.proname) end as object_name,
+            'function' as object_type
+        from
+            pg_catalog.pg_proc p
+            inner join nsp on nsp.oid = p.pronamespace
+        where
+            p.proname ~ '[A-Z]'
+
+        union all
+
+        select
+            case when nsp.nspname = 'public' then quote_ident(c.conname) else quote_ident(nsp.nspname) || '.' || quote_ident(c.conname) end as object_name,
+            'constraint' as object_type
+        from
+            pg_catalog.pg_constraint c
+            inner join nsp on nsp.oid = c.connamespace
+        where
+            c.conname ~ '[A-Z]' and
+            c.conparentid = 0 and c.coninhcount = 0 /* not a constraint in a partition */
+
+        union all
+
+        select
+            pc.oid::regclass::text || '.' || quote_ident(col.attname) as object_name,
+            'column' as object_type
+        from
+            pg_catalog.pg_attribute col
+            inner join pg_catalog.pg_class pc on pc.oid = col.attrelid
+            inner join nsp on nsp.oid = pc.relnamespace
+        where
+            pc.relkind in ('r', 'p') and
+            /* decided not to filter by the pc.relispartition field here */
+            col.attnum > 0 and
+            not col.attisdropped and
+            col.attname ~ '[A-Z]'
+    )
+
+select *
+from upper_case_names
+order by object_type, object_name;

--- a/sql/objects_with_upper_case_names.sql
+++ b/sql/objects_with_upper_case_names.sql
@@ -63,21 +63,6 @@ with
             c.conname ~ '[A-Z]' and
             c.conparentid = 0 and c.coninhcount = 0 /* not a constraint in a partition */
 
-        union all
-
-        select
-            pc.oid::regclass::text || '.' || quote_ident(col.attname) as object_name,
-            'column' as object_type
-        from
-            pg_catalog.pg_attribute col
-            inner join pg_catalog.pg_class pc on pc.oid = col.attrelid
-            inner join nsp on nsp.oid = pc.relnamespace
-        where
-            pc.relkind in ('r', 'p') and
-            /* decided not to filter by the pc.relispartition field here */
-            col.attnum > 0 and
-            not col.attisdropped and
-            col.attname ~ '[A-Z]'
     )
 
 select *

--- a/sql/primary_keys_that_most_likely_natural_keys.sql
+++ b/sql/primary_keys_that_most_likely_natural_keys.sql
@@ -20,21 +20,21 @@ with
     )
 
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     c.conindid::regclass::text as index_name,
     pg_relation_size(c.conindid) as index_size,
     array_agg(quote_ident(col.attname) || ',' || col.attnotnull::text order by u.attposition) as columns
 from
     pg_catalog.pg_constraint c
-    inner join pg_catalog.pg_class t on t.oid = c.conrelid
+    inner join pg_catalog.pg_class pc on pc.oid = c.conrelid
     inner join nsp on nsp.oid = c.connamespace
     inner join lateral unnest(c.conkey) with ordinality u(attnum, attposition) on true
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid and col.attnum = u.attnum
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid and col.attnum = u.attnum
 where
     c.contype = 'p' and /* primary key constraint */
     c.conparentid = 0 and c.coninhcount = 0 and /* not a constraint in a partition */
-    t.relkind = 'r' /* only regular tables */
-group by t.oid, c.conindid
+    pc.relkind = 'r' /* only regular tables */
+group by pc.oid, c.conindid
 having bool_or(
         col.atttypid not in (
             'smallint'::regtype,
@@ -47,22 +47,22 @@ having bool_or(
 union all
 
 select
-    t.oid::regclass::text as table_name,
+    pc.oid::regclass::text as table_name,
     c.conindid::regclass::text as index_name,
     pg_relation_size(c.conindid) as index_size,
     array_agg(quote_ident(col.attname) || ',' || col.attnotnull::text order by u.attposition) as columns
 from
     pg_catalog.pg_constraint c
-    inner join pg_catalog.pg_class t on t.oid = c.conrelid
+    inner join pg_catalog.pg_class pc on pc.oid = c.conrelid
     inner join nsp on nsp.oid = c.connamespace
     inner join lateral unnest(c.conkey) with ordinality u(attnum, attposition) on true
-    inner join pg_catalog.pg_attribute col on col.attrelid = t.oid and col.attnum = u.attnum
+    inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid and col.attnum = u.attnum
 where
     c.contype = 'p' and /* primary key constraint */
     c.conparentid = 0 and c.coninhcount = 0 and /* not a constraint in a partition */
-    t.relkind = 'p' and /* only partitioned tables */
-    not t.relispartition
-group by t.oid, c.conindid
+    pc.relkind = 'p' and /* only partitioned tables */
+    not pc.relispartition
+group by pc.oid, c.conindid
 having bool_or(
         /* for partitioned tables decided to allow a few more data types that usually are used in ranges */
         col.atttypid not in (

--- a/sql/primary_keys_with_serial_types.sql
+++ b/sql/primary_keys_with_serial_types.sql
@@ -32,9 +32,9 @@ with
             end as column_type,
             pg_get_expr(ad.adbin, ad.adrelid) as column_default_value
         from
-            pg_catalog.pg_class t
-            inner join nsp on nsp.oid = t.relnamespace
-            inner join pg_catalog.pg_attribute col on col.attrelid = t.oid
+            pg_catalog.pg_class pc
+            inner join nsp on nsp.oid = pc.relnamespace
+            inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
             inner join pg_catalog.pg_constraint c on c.conrelid = col.attrelid and col.attnum = any(c.conkey)
             inner join pg_catalog.pg_attrdef ad on ad.adrelid = col.attrelid and ad.adnum = col.attnum
             inner join pg_catalog.pg_depend dep on dep.refobjid = col.attrelid and dep.refobjsubid = col.attnum

--- a/sql/sequence_overflow.sql
+++ b/sql/sequence_overflow.sql
@@ -18,16 +18,16 @@ with
             s.seqmax as max_value,
             s.seqincrement as increment_by,
             case
-                when has_sequence_privilege(c.oid, 'select,usage'::text) then pg_sequence_last_value(c.oid::regclass)
+                when has_sequence_privilege(pc.oid, 'select,usage'::text) then pg_sequence_last_value(pc.oid::regclass)
                 else null::bigint
             end as last_value
         from
             pg_catalog.pg_sequence s
-            inner join pg_catalog.pg_class c on c.oid = s.seqrelid
-            left join pg_catalog.pg_namespace nsp on nsp.oid = c.relnamespace
+            inner join pg_catalog.pg_class pc on pc.oid = s.seqrelid
+            left join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
         where
             not pg_is_other_temp_schema(nsp.oid) and /* not temporary */
-            c.relkind = 'S'::char and /* sequence object */
+            pc.relkind = 'S'::char and /* sequence object */
             not s.seqcycle and /* skip cycle sequences */
             nsp.nspname = :schema_name_param::text
     ),

--- a/sql/tables_with_inheritance.sql
+++ b/sql/tables_with_inheritance.sql
@@ -14,7 +14,7 @@ select
     pc.oid::regclass::text as table_name,
     pg_table_size(pc.oid) as table_size
 from
-    pg_catalog.pg_class pc
+        pg_catalog.pg_class pc
     inner join pg_catalog.pg_inherits i on i.inhrelid = pc.oid /* child table oid */
     inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
 where

--- a/sql/tables_with_inheritance.sql
+++ b/sql/tables_with_inheritance.sql
@@ -14,7 +14,7 @@ select
     pc.oid::regclass::text as table_name,
     pg_table_size(pc.oid) as table_size
 from
-        pg_catalog.pg_class pc
+    pg_catalog.pg_class pc
     inner join pg_catalog.pg_inherits i on i.inhrelid = pc.oid /* child table oid */
     inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
 where


### PR DESCRIPTION
Part of https://github.com/mfvanek/pg-index-health/issues/745

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [ ] Sql query has a brief description
- [ ] Sql query contains filtering by schema name
- [ ] All tables, indexes and sequences names in the query results are schema-qualified
- [ ] All names have been enclosed in double quotes (if necessary)
- [ ] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
