### PR TITLE
Add a check for tables with incrementing column names [schemacrawler]

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 41. Tables with no data ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_no_data.sql)).
 42. Self-referenced foreign keys ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/self_referenced_foreign_keys.sql)).
 43. Columns with [large objects type (BLOB/CLOB)](https://www.postgresql.org/docs/current/largeobjects.html) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_blob_type.sql)).
+44. Tables with incrementing column names ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_incrementing_columns.sql)).
 
 ## Local development
 

--- a/sql/tables_with_incrementing_columns.sql
+++ b/sql/tables_with_incrementing_columns.sql
@@ -9,8 +9,8 @@
 -- which indicates de-normalization that could be replaced with a separate child table and a foreign key.
 -- Groups columns by their shared base name (the non-numeric prefix) and reports any group of two or more.
 --
--- See https://www.schemacrawler.com/lint.html
 -- Similar to schemacrawler.tools.linter.LinterTableWithIncrementingColumns
+-- https://www.schemacrawler.com/lint.html
 with
     column_patterns as (
         select

--- a/sql/tables_with_incrementing_columns.sql
+++ b/sql/tables_with_incrementing_columns.sql
@@ -31,13 +31,23 @@ with
             not col.attisdropped and
             col.attname ~ '^\D+\d+$' and /* column name ends with digits and starts with at least one non-digit */
             nsp.nspname = :schema_name_param::text
+    ),
+
+    groups_with_two_or_more as (
+        select
+            oid,
+            base_name
+        from column_patterns
+        group by oid, base_name
+        having count(*) >= 2
     )
 
 select
-    table_name,
-    pg_table_size(oid) as table_size,
-    array_agg(quote_ident(attname) || ',' || attnotnull::text order by attposition) as columns
-from column_patterns
-group by oid, table_name, base_name
-having count(*) >= 2
-order by table_name, columns[1];
+    cp.table_name,
+    pg_table_size(cp.oid) as table_size,
+    array_agg(quote_ident(cp.attname) || ',' || cp.attnotnull::text order by cp.attposition) as columns
+from
+    column_patterns cp
+    inner join groups_with_two_or_more g on g.oid = cp.oid and g.base_name = cp.base_name
+group by cp.oid, cp.table_name
+order by cp.table_name;

--- a/sql/tables_with_incrementing_columns.sql
+++ b/sql/tables_with_incrementing_columns.sql
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds tables with incrementing column names (for example, contact1, contact2, contact3),
+-- which indicates de-normalization that could be replaced with a separate child table and a foreign key.
+-- Groups columns by their shared base name (the non-numeric prefix) and reports any group of two or more.
+--
+-- See https://www.schemacrawler.com/lint.html
+-- Similar to schemacrawler.tools.linter.LinterTableWithIncrementingColumns
+with
+    column_patterns as (
+        select
+            pc.oid,
+            pc.oid::regclass::text as table_name,
+            col.attname,
+            col.attnotnull,
+            col.attnum as attposition,
+            regexp_replace(col.attname, '\d+$', '') as base_name
+        from
+            pg_catalog.pg_class pc
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+            inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
+        where
+            pc.relkind in ('r', 'p') and
+            not pc.relispartition and
+            col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
+            not col.attisdropped and
+            col.attname ~ '^\D+\d+$' and /* column name ends with digits and starts with at least one non-digit */
+            nsp.nspname = :schema_name_param::text
+    )
+
+select
+    table_name,
+    pg_table_size(oid) as table_size,
+    array_agg(quote_ident(attname) || ',' || attnotnull::text order by attposition) as columns
+from column_patterns
+group by oid, table_name, base_name
+having count(*) >= 2
+order by table_name, columns[1];


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/633

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [x] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
