### PR TITLE
Add a check for columns with inconsistent types [schemacrawler]

### DIFF
--- a/.github/linters/.sqlfluff
+++ b/.github/linters/.sqlfluff
@@ -6,7 +6,7 @@ templater = raw
 
 [sqlfluff:indentation]
 indented_joins = True
-allow_implicit_indents = True
+implicit_indents = allow
 indented_on_contents = False
 indented_ctes = True
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ docker run \
   -e USE_FIND_ALGORITHM=true \
   -e VALIDATE_SQLFLUFF=true \
   -v $(pwd):/tmp/lint \
-  ghcr.io/super-linter/super-linter:slim-v8.6.0
+  ghcr.io/super-linter/super-linter:slim-v8.7.0
 ```
 
 **Windows (PowerShell):**
@@ -31,7 +31,7 @@ docker run `
   -e USE_FIND_ALGORITHM=true `
   -e VALIDATE_SQLFLUFF=true `
   -v "${PWD}:/tmp/lint" `
-  ghcr.io/super-linter/super-linter:slim-v8.6.0
+  ghcr.io/super-linter/super-linter:slim-v8.7.0
 ```
 
 SQLFluff configuration lives in `.github/linters/.sqlfluff` (PostgreSQL dialect, max line length 280).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git Commits (for AI agents)
+
+**Never commit changes until the user explicitly asks.** Every commit must be approved by the user.
+Make and stage edits as needed, but do not run `git commit` (or `git push`) on your own initiative —
+wait for an explicit instruction such as "commit" or "push" from the user.
+
 ## Project Overview
 
 **pg-index-health-sql** is a collection of PostgreSQL diagnostic SQL queries that detect structural issues in database schemas.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For more information please see [PostgreSQL Versioning Policy](https://www.postg
 42. Self-referenced foreign keys ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/self_referenced_foreign_keys.sql)).
 43. Columns with [large objects type (BLOB/CLOB)](https://www.postgresql.org/docs/current/largeobjects.html) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_blob_type.sql)).
 44. Tables with incrementing column names ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/tables_with_incrementing_columns.sql)).
+45. Columns with inconsistent types (the same name but different data types) ([sql](https://github.com/mfvanek/pg-index-health-sql/blob/master/sql/columns_with_inconsistent_types.sql)).
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ docker run \
   -e USE_FIND_ALGORITHM=true \
   -e VALIDATE_SQLFLUFF=true \
   -v $(pwd):/tmp/lint \
-  ghcr.io/super-linter/super-linter:slim-v8.6.0
+  ghcr.io/super-linter/super-linter:slim-v8.7.0
 ```
 
 #### Windows
@@ -101,7 +101,7 @@ docker run ^
   -e USE_FIND_ALGORITHM=true ^
   -e VALIDATE_SQLFLUFF=true ^
   -v "%cd%":/tmp/lint ^
-  ghcr.io/super-linter/super-linter:slim-v8.6.0
+  ghcr.io/super-linter/super-linter:slim-v8.7.0
 ```
 
 See https://github.com/super-linter/super-linter/blob/main/dependencies/python/sqlfluff.txt
@@ -111,5 +111,5 @@ docker run --rm ^
   -v "%cd%\.github\linters\.sqlfluff":/sql/.sqlfluff:ro ^
   -v "%cd%":/sql ^
   -e SQLFLUFF_CONFIG=/sql/.sqlfluff ^
-  sqlfluff/sqlfluff:4.1.0 lint /sql
+  sqlfluff/sqlfluff:4.2.2 lint /sql
 ```

--- a/sql/columns_with_inconsistent_types.sql
+++ b/sql/columns_with_inconsistent_types.sql
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019-2026. Ivan Vakhrushev and others.
+ * https://github.com/mfvanek/pg-index-health-sql
+ *
+ * Licensed under the Apache License 2.0
+ */
+
+-- Finds columns in different tables that share the same name but have different data types.
+-- Inconsistent types for the same column name make joins and application code error-prone.
+-- Primary keys (e.g. 'id') are intentionally not excluded to force a single type for all such columns within a schema.
+--
+-- Similar to schemacrawler.tools.linter.LinterColumnTypes https://www.schemacrawler.com/lint.html
+with
+    columns_info as (
+        select
+            pc.oid::regclass::text as table_name,
+            col.attnotnull as column_not_null,
+            col.atttypid::regtype::text as column_type,
+            col.attname as raw_column_name
+        from
+            pg_catalog.pg_class pc
+            inner join pg_catalog.pg_namespace nsp on nsp.oid = pc.relnamespace
+            inner join pg_catalog.pg_attribute col on col.attrelid = pc.oid
+        where
+            pc.relkind in ('r', 'p') and
+            not pc.relispartition and
+            col.attnum > 0 and /* to filter out system columns such as oid, ctid, xmin, xmax, etc. */
+            not col.attisdropped and
+            nsp.nspname = :schema_name_param::text
+    )
+
+select
+    ci.table_name,
+    ci.column_not_null,
+    ci.column_type,
+    quote_ident(ci.raw_column_name) as column_name
+from
+    columns_info ci
+where
+    ci.raw_column_name in (
+        select inner_ci.raw_column_name
+        from columns_info inner_ci
+        group by inner_ci.raw_column_name
+        having count(distinct inner_ci.column_type) > 1
+    )
+order by column_name, table_name;


### PR DESCRIPTION
Relates to https://github.com/mfvanek/pg-index-health/issues/628

### Common steps

- [x] Read [CONTRIBUTING.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/CONTRIBUTING.md)
- [x] Linked to an issue
- [x] Added a description to PR

### For a database check

- [x] Name of the sql file with the query correspond to a diagnostic name in [Java project](https://github.com/mfvanek/pg-index-health)
- [x] Sql query has a brief description
- [x] Sql query contains filtering by schema name
- [x] All tables, indexes and sequences names in the query results are schema-qualified
- [x] All names have been enclosed in double quotes (if necessary)
- [x] The columns for the index or foreign key have been returned in the order they are used in the index or foreign key
- [x] All query results have been ordered
- [ ] I have updated the [README.md](https://github.com/mfvanek/pg-index-health-sql/blob/master/README.md)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No
